### PR TITLE
Make the authorization ECR configurable

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -1,0 +1,57 @@
+###Added Configuration of ECR_Roles###
+
+1. Added ECR_Roles to verifier-config-public.json
+"ECR_Roles": []
+
+2. Loaded configuration for ECR_Roles in authorizing.py
+if "ECR_Roles" not in data:
+        raise kering.ConfigurationError(
+            "invalid configuration, no ECR_Roles available to accept"
+        )
+    
+    ecr_roles = data.get("ECR_Roles")
+    if not None and not isinstance(leis, list):
+        raise kering.ConfigurationError(
+            "invalid configuration, invalid ECR_Roles in configuration"
+        )
+
+3. Then updated the Authorizer constructor to be able to handle set of ecr roles
+
+authorizer = Authorizer(hby, vdb, reger, leis, ecr_roles)
+
+def __init__(self, hby, vdb, reger, leis, ecr_roles):
+        """
+        Create a Authenticator capable of persistent processing of messages and performing
+        web hook calls.
+
+        Parameters:
+            hby (Habery): identifier database environment
+            vdb (VerifierBaser): communication escrow database environment
+            reger (Reger): credential registry and database
+            leis (list): list of str LEIs to accept credential presentations from
+            ecr_roles (list): list of str ecr_roles to accept
+
+        """
+        self.hby = hby
+        self.vdb = vdb
+        self.reger = reger
+        self.leis = leis
+        self.ecr_roles = ecr_roles
+
+4) Updated cred_filters() in the Authorizer class so that it doesn't check for the hardcoded EBA role
+
+elif len(self.ecr_roles) > 0 and creder.attrib["engagementContextRole"] not in (self.ecr_roles):
+                res = False, f"{creder.attrib["engagementContextRole"]} is not a valid submitter role"
+
+5) Created 2 sample ECR_Role constants in common.py
+
+ECR_ROLE1 = "EBA Data Submitter"
+ECR_ROLE2 = "EBA Data Admin"
+
+6) Modfied the testCf class in test-service.py to return a dictionary that contains both ECR_Role constants like it does for the LEIs
+
+class testCf:
+            @staticmethod
+            def get():
+                return dict(LEIs=[f"{LEI1}",f"{LEI2}"], ECR_Roles=[f"{ECR_ROLE1}",f"{ECR_ROLE2}"])
+        authDoers = authorizing.setup(hby, vdb=vdb, reger=eccrdntler.rgy.reger, cf=testCf)

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -1,4 +1,4 @@
-###Added Configuration of ECR_Roles###
+### Added Configuration of ECR_Roles ###
 
 1. Added ECR_Roles to verifier-config-public.json
 "ECR_Roles": []

--- a/scripts/keri/cf/verifier-config-public.json
+++ b/scripts/keri/cf/verifier-config-public.json
@@ -29,5 +29,6 @@
     "https://gleif-it.github.io/oobi/EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g",
     "https://gleif-it.github.io/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"
   ],
-  "LEIs": []
+  "LEIs": [],
+  "ECR_Roles": []
 }

--- a/src/verifier/app/cli/commands/server/start.py
+++ b/src/verifier/app/cli/commands/server/start.py
@@ -14,7 +14,7 @@ from keri.app import keeping, configing, habbing, oobiing
 from keri.app.cli.common import existing
 from keri.vdr import viring
 import logging
-from verifier.core import verifying, authorizing, basing, reporting
+from src.verifier.core import verifying, authorizing, basing, reporting
 
 parser = argparse.ArgumentParser(description='Launch vLEI Verification Service')
 parser.set_defaults(handler=lambda args: launch(args),

--- a/src/verifier/core/authorizing.py
+++ b/src/verifier/core/authorizing.py
@@ -13,8 +13,8 @@ from keri import kering
 from keri.core import coring
 from keri.help import helping
 
-from verifier.core.basing import Account, CredProcessState, AUTH_REVOKED
-from verifier.core.verifying import CRED_CRYPT_VALID
+from src.verifier.core.basing import Account, CredProcessState, AUTH_REVOKED
+from src.verifier.core.verifying import CRED_CRYPT_VALID
 
 # Hard-coded vLEI Engagement context role to accept.  This would be configurable in production
 EBA_DOCUMENT_SUBMITTER_ROLE = "EBA Data Submitter"

--- a/src/verifier/core/reporting.py
+++ b/src/verifier/core/reporting.py
@@ -14,8 +14,8 @@ from hio.base import doing
 from keri import kering
 from keri.core import Siger
 
-from verifier.core.basing import delete_upload_status, ReportStats, ReportStatus, save_upload_status, UploadStatus
-from verifier.core.utils import DigerBuilder
+from src.verifier.core.basing import delete_upload_status, ReportStats, ReportStatus, save_upload_status, UploadStatus
+from src.verifier.core.utils import DigerBuilder
 
 # help.ogler.level = logging.getLevelName("DEBUG")
 # logger = help.ogler.getLogger()

--- a/src/verifier/core/utils.py
+++ b/src/verifier/core/utils.py
@@ -2,7 +2,7 @@ from keri import kering
 from keri.core import MtrDex, coring
 from keri.vdr.eventing import state
 
-from verifier.core.basing import AUTH_REVOKED, CredProcessState
+from src.verifier.core.basing import AUTH_REVOKED, CredProcessState
 
 
 class DigerBuilder:

--- a/src/verifier/core/verifying.py
+++ b/src/verifier/core/verifying.py
@@ -4,13 +4,13 @@ import json
 
 from keri.core import coring, parsing
 from keri.vdr import verifying, eventing
-from verifier.core.basing import (
+from src.verifier.core.basing import (
     CRED_CRYPT_INVALID,
     CRED_CRYPT_VALID,
     CredProcessState,
     cred_age_off, AUTH_REVOKED,
 )
-from verifier.core.utils import process_revocations
+from src.verifier.core.utils import process_revocations
 
 
 def setup(app, hby, vdb, reger, local=False):

--- a/tests/common.py
+++ b/tests/common.py
@@ -261,7 +261,7 @@ def get_da_cred(issuer, schema, registry):
 
     return creder   
 
-def get_ecr_auth_cred(aid, issuer, recipient, schema, registry, sedge, lei: str, role: str):
+def get_ecr_auth_cred(aid, issuer, recipient, schema, registry, sedge, lei: str, role="EBA Data Submitter"):
     sad = dict(get_ecr_data(lei, role))
     sad["AID"]=f'{aid}'
     
@@ -336,7 +336,7 @@ def get_ecr_data(lei: str, role="EBA Data Submitter"):
         LEI=f"{lei}"
     )
 
-def get_ecr_cred(issuer, recipient, schema, registry, sedge, lei: str, role: str):
+def get_ecr_cred(issuer, recipient, schema, registry, sedge, lei: str, role="EBA Data Submitter"):
 
     sad = get_ecr_data(lei, role)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,6 +14,9 @@ from keri.vdr.credentialing import Credentialer, proving
 LEI1 = "254900OPPU84GM83MG36"
 LEI2 = "875500ELOZEL05BVXV37"
 
+ECR_ROLE1 = "EBA Data Submitter"
+ECR_ROLE2 = "EBA Data Admin"
+
 # @pytest.fixture
 # def setup_habs():
 #     with habbing.openHby(name="test", temp=True) as hby, habbing.openHby(
@@ -258,8 +261,8 @@ def get_da_cred(issuer, schema, registry):
 
     return creder   
 
-def get_ecr_auth_cred(aid, issuer, recipient, schema, registry, sedge, lei: str):
-    sad = dict(get_ecr_data(lei))
+def get_ecr_auth_cred(aid, issuer, recipient, schema, registry, sedge, lei: str, role: str):
+    sad = dict(get_ecr_data(lei, role))
     sad["AID"]=f'{aid}'
     
     _, ecr_auth = coring.Saider.saidify(sad=sad, label=coring.Saids.d)
@@ -316,17 +319,26 @@ def get_ecr_edge(auth_dig, auth_schema):
   
     return ecr
 
-def get_ecr_data(lei: str):
+def get_ecr_data(lei: str, role="EBA Data Submitter"):
+    #below is the original dictionary which assumes ecr role of EBA Data Submitter
+    # return dict(
+    #     d="",
+    #     personLegalName="Bank User",
+    #     engagementContextRole="EBA Data Submitter",
+    #     LEI=f"{lei}"
+    # )
+
+    #let's create a new dictionary with our variable ecr role
     return dict(
         d="",
         personLegalName="Bank User",
-        engagementContextRole="EBA Data Submitter",
+        engagementContextRole=f"{role}",
         LEI=f"{lei}"
     )
 
-def get_ecr_cred(issuer, recipient, schema, registry, sedge, lei: str):
+def get_ecr_cred(issuer, recipient, schema, registry, sedge, lei: str, role: str):
 
-    sad = get_ecr_data(lei)
+    sad = get_ecr_data(lei, role)
 
     _, ecr = coring.Saider.saidify(sad=sad, label=coring.Saids.d)
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import multicommand
 import pytest
 from hio.base import doing
 
-from verifier.core.authorizing import Schema
+from src.verifier.core.authorizing import Schema
 
 from keri import kering
 from keri.core import scheming, coring, routing, eventing, parsing

--- a/tests/core/test_authorizing.py
+++ b/tests/core/test_authorizing.py
@@ -58,6 +58,7 @@ def test_ecr(seeder):
             registry=registry,
             sedge=eaedge,
             lei=LEI1,
+            role=ECR_ROLE2,
         )
         hab, eacrdntler, easaid, eakmsgs, eatmsgs, eaimsgs, eamsgs = get_cred(
             hby, hab, regery, registry, verifier, Schema.ECR_AUTH_SCHEMA2, ecr_auth_cred, seqner
@@ -68,7 +69,7 @@ def test_ecr(seeder):
         issAndCred.extend(eamsgs)
         acdc = issAndCred.decode("utf-8")
         hby.kevers[hab.pre] = hab.kever
-        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1])
+        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1], [ECR_ROLE2])
         chain_success, chain_msg = auth.chain_filters(ecr_auth_cred)
         assert chain_success
         assert chain_msg == f"QVI->LE->ECR_AUTH"
@@ -86,6 +87,7 @@ def test_ecr(seeder):
             registry=registry,
             sedge=ecredge,
             lei=LEI1,
+            role=ECR_ROLE2
         )
         hab, eccrdntler, ecsaid, eckmsgs, ectmsgs, ecimsgs, ecmsgs = get_cred(
             hby, hab, regery, registry, verifier, Schema.ECR_SCHEMA, ecr_cred, seqner
@@ -94,7 +96,7 @@ def test_ecr(seeder):
         issAndCred = bytearray()
         issAndCred.extend(ecmsgs)
         hby.kevers[hab.pre] = hab.kever
-        auth = Authorizer(hby, vdb, eccrdntler.rgy.reger, [LEI1])
+        auth = Authorizer(hby, vdb, eccrdntler.rgy.reger, [LEI1], [ECR_ROLE2])
         chain_success, chain_msg = auth.chain_filters(ecr_cred)
         assert chain_success
         assert chain_msg == f"QVI->LE->ECR_AUTH->ECR"

--- a/tests/core/test_authorizing.py
+++ b/tests/core/test_authorizing.py
@@ -9,8 +9,8 @@ from keri.vdr import viring
 
 import pytest
 
-from verifier.core import basing, verifying
-from verifier.core.authorizing import Authorizer, Schema
+from src.verifier.core import basing, verifying
+from src.verifier.core.authorizing import Authorizer, Schema
 
 def test_ecr(seeder):
 

--- a/tests/core/test_basing.py
+++ b/tests/core/test_basing.py
@@ -3,7 +3,7 @@ import os
 import lmdb
 from keri.db import subing, koming
 
-from verifier.core.basing import VerifierBaser
+from src.verifier.core.basing import VerifierBaser
 
 
 def test_vdb():

--- a/tests/core/test_file_processor.py
+++ b/tests/core/test_file_processor.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 
-from verifier.core.reporting import DOC_INFO, FileProcessor
+from src.verifier.core.reporting import DOC_INFO, FileProcessor
 
 class TestFileProcessor(unittest.TestCase):
     def setUp(self):

--- a/tests/core/test_verifying.py
+++ b/tests/core/test_verifying.py
@@ -9,8 +9,8 @@ from keri.vdr import viring
 
 import pytest
 
-from verifier.core import verifying, basing
-from verifier.core.authorizing import Authorizer, Schema
+from src.verifier.core import verifying, basing
+from src.verifier.core.authorizing import Authorizer, Schema
 
 # @pytest.fixture(autouse=True)
 # def setup():

--- a/tests/core/test_verifying.py
+++ b/tests/core/test_verifying.py
@@ -137,6 +137,7 @@ def test_ecr(seeder):
             registry=registry,
             sedge=eaedge,
             lei=LEI1,
+            role=ECR_ROLE2,
         )
         hab, eacrdntler, easaid, eakmsgs, eatmsgs, eaimsgs, eamsgs = get_cred(
             hby, hab, regery, registry, verifier, Schema.ECR_AUTH_SCHEMA2, eacred, seqner
@@ -156,7 +157,7 @@ def test_ecr(seeder):
         # ecr auth cred is verified to be a valid credential
         assert result.status == falcon.HTTP_202
         hby.kevers[hab.pre] = hab.kever
-        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1])
+        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1], [ECR_ROLE2])
         auth.processPresentations()
         # ecr auth cred is not authorized
         result = client.simulate_get(f"/authorizations/{hab.pre}")
@@ -172,6 +173,7 @@ def test_ecr(seeder):
             registry=registry,
             sedge=ecredge,
             lei=LEI1,
+            role=ECR_ROLE2,
         )
         hab, eccrdntler, ecsaid, eckmsgs, ectmsgs, ecimsgs, ecmsgs = get_cred(
             hby, hab, regery, registry, verifier, Schema.ECR_SCHEMA, ecr, seqner
@@ -189,7 +191,7 @@ def test_ecr(seeder):
         )
         assert result.status == falcon.HTTP_202
         hby.kevers[hab.pre] = hab.kever
-        auth = Authorizer(hby, vdb, eccrdntler.rgy.reger, [LEI1])
+        auth = Authorizer(hby, vdb, eccrdntler.rgy.reger, [LEI1], [ECR_ROLE2])
         auth.processPresentations()
 
         result = client.simulate_get(f"/authorizations/{hab.pre}")
@@ -235,7 +237,7 @@ def test_ecr(seeder):
         # ecr auth cred is verified to be a valid credential
         assert result.status == falcon.HTTP_202
         hby.kevers[hab.pre] = hab.kever
-        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1])
+        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1], [ECR_ROLE2])
         auth.processPresentations()
         # ecr auth cred is not authorized
         result = client.simulate_get(f"/authorizations/{hab.pre}")
@@ -287,6 +289,7 @@ def test_ecr_missing(seeder):
             registry=registry,
             sedge=eaedge,
             lei=LEI1,
+            role=ECR_ROLE2,
         )
         hab, eacrdntler, easaid, eakmsgs, eatmsgs, eaimsgs, eamsgs = get_cred(
             hby, hab, regery, registry, verifier, Schema.ECR_AUTH_SCHEMA2, eacred, seqner
@@ -329,7 +332,7 @@ def test_ecr_missing(seeder):
 
         hby.kevers[hab.pre] = hab.kever
 
-        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1])
+        auth = Authorizer(hby, vdb, eacrdntler.rgy.reger, [LEI1], [ECR_ROLE2])
         auth.processPresentations()
 
         result = client.simulate_get(f"/authorizations/{hab.pre}")

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -8,10 +8,10 @@ import pytest
 import requests
 import threading
 import time
-import verifier.app.cli.commands.server.start as start
-from verifier.core import verifying, basing
-import verifier.core.authorizing as authorizing
-import verifier.core.reporting as reporting
+import src.verifier.app.cli.commands.server.start as start
+from src.verifier.core import verifying, basing
+import src.verifier.core.authorizing as authorizing
+import src.verifier.core.reporting as reporting
 
 host = "localhost"
 port = 7676

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -33,13 +33,13 @@ def test_service_ecr(seeder):
         #chained ecr auth cred
         eaedge = get_ecr_auth_edge(lsaid,Schema.LE_SCHEMA1)
         
-        eacred = get_ecr_auth_cred(aid=hab.pre, issuer=hab.pre, recipient=hab.pre, schema=Schema.ECR_AUTH_SCHEMA2, registry=registry, sedge=eaedge, lei=LEI1)
+        eacred = get_ecr_auth_cred(aid=hab.pre, issuer=hab.pre, recipient=hab.pre, schema=Schema.ECR_AUTH_SCHEMA2, registry=registry, sedge=eaedge, lei=LEI1, role=ECR_ROLE2)
         hab, eacrdntler, easaid, eakmsgs, eatmsgs, eaimsgs, eamsgs = get_cred(hby, hab, regery, registry, verifier, Schema.ECR_AUTH_SCHEMA2, eacred, seqner)
         
         #chained ecr auth cred
         ecredge = get_ecr_edge(easaid,Schema.ECR_AUTH_SCHEMA2)
         
-        ecr = get_ecr_cred(issuer=hab.pre, recipient=hab.pre, schema=Schema.ECR_SCHEMA, registry=registry, sedge=ecredge, lei=LEI1)
+        ecr = get_ecr_cred(issuer=hab.pre, recipient=hab.pre, schema=Schema.ECR_SCHEMA, registry=registry, sedge=ecredge, lei=LEI1, role=ECR_ROLE2,)
         hab, eccrdntler, ecsaid, eckmsgs, ectmsgs, ecimsgs, ecmsgs = get_cred(hby, hab, regery, registry, verifier, Schema.ECR_SCHEMA, ecr, seqner)
         
         app = falcon.App(
@@ -54,7 +54,7 @@ def test_service_ecr(seeder):
         class testCf:
             @staticmethod
             def get():
-                return dict(LEIs=[f"{LEI1}",f"{LEI2}"])
+                return dict(LEIs=[f"{LEI1}",f"{LEI2}"], ECR_Roles=[f"{ECR_ROLE1}",f"{ECR_ROLE2}"])
         authDoers = authorizing.setup(hby, vdb=vdb, reger=eccrdntler.rgy.reger, cf=testCf)
 
         doers = authDoers + [httpServerDoer]


### PR DESCRIPTION
### Objective ###
Make the ECR (Engagement Context Role) configurable in the vlei-verifier,  instead of being hardcoded to a single role (EBA Data Submitter), and allowing it to support multiple roles. This will make the system more generic and adaptable for various vLEI use cases.

### Changes Made ###

1. Added Configuration to verifier-config-public.json: "ECR_Roles": []
2. Checked for "ECR_ROLES" in cf dictionary in setup() in authorizing.py, similar to how this is done for LEIs
3. Changed the Authorizer constructor to accept the set of ecr_roles from this data
4. Removed usage of the hard-coded EBA value from the cred_filters() function in the Authorizer class, instead having it check the new ecr_roles variable.
5. Added 2 EBA_Role constants to common.py, similar to what is done for LEIs
6. Changed function definitions in common.py(get_ecr_auth_cred, get_ecr_data, get_ecr_cred) to allow for the ecr_role variable that defaults to "EBA Data Submitter" if no value is passed in
7. Changed function calls in test_authorizing.py, test_verifying.py, and test_service.py to account for new ecr_role data being passed in
8. Modfied the testCf class in test-service.py to return a dictionary that contains both ECR_Role constants like it does for the LEIs