### PR TITLE
Added clearData to the reporting.py to clear report files from DB after processing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## [v0.0.3] - 2024-12-18
+
+### Added
+- **Configurable Parameters**: The Verifier now supports the following configuration options:
+  - `iurls`: OOBI URLs.
+  - `durls`: Schema OOBI URLs.
+  - `trustedLeis`: A list of trusted LE identifiers.
+  - `allowedEcrRoles`: Roles permitted for ECR credential authorization.
+  - `allowedOorRoles`: Roles permitted for OOR credential authorization.
+  - `allowedSchemas`: A list of schemas allowed for authorization.
+
+- **Environment Variables**:
+  - `VERIFIER_ENV`: Sets the environment mode (e.g., `dev` or `production`). Defaults to `production`. In `production` mode, the `/root_of_trust` endpoint is disabled.
+  - `VERIFY_ROOT_OF_TRUST`: Enables or disables root of trust validation logic. Defaults to `True`.
+  - `KERI_BASER_MAP_SIZE`: Defines the maximum size of the LMDB database. Defaults to `104857600` (100 MB).
+  - `FILER_CHUNK_SIZE`: Defines the size of the chunks used for file processing. This allows fine-tuning of memory usage when handling large files.
+
+- **Automatic LMDB Cleanup**: 
+  - Processed reports are now automatically removed from the LMDB database after verification, preventing database size issues.
+
+### Fixed
+- Resolved an issue where uploading multiple reports caused the Verifier to crash with the error:  
+  `lmdb.MapFullError: mdb_put: MDB_MAP_FULL: Environment mapsize limit reached`.
+
+### Example Command
+To run the Verifier service, specify the configuration file as follows:
+```bash
+verifier server start --config-dir scripts --config-file verifier-config-rootsid.json
+```
+
+### Summary
+
+This release improves the usability and reliability of the Verifier service by introducing support for configurable parameters, environment variables, and automatic cleanup of processed reports in the LMDB database.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup
 
 setup(
     name='verifier',
-    version='0.0.2',  # also change in src/verifier/__init__.py
+    version='0.0.3',  # also change in src/verifier/__init__.py
     license='Apache Software License 2.0',
     description='Verifier: Proof of Concept vLEI Verifier',
     long_description="Verifier: Proof of Concept vLEI Verifier.",

--- a/src/verifier/core/basing.py
+++ b/src/verifier/core/basing.py
@@ -5,6 +5,7 @@ verifier.core.basing module
 
 Database support
 """
+import os
 from collections import namedtuple
 from dataclasses import dataclass, asdict, field
 from typing import List
@@ -129,6 +130,7 @@ class VerifierBaser(dbing.LMDBer):
     TailDirPath = "keri/vdb"
     AltTailDirPath = ".verifier/vdb"
     TempPrefix = "keri_vdb_"
+    KERIBaserMapSizeKey = "KERI_BASER_MAP_SIZE"
 
     def __init__(self, name="vdb", headDirPath=None, reopen=True, **kwa):
         """  Create verifier database
@@ -155,6 +157,13 @@ class VerifierBaser(dbing.LMDBer):
 
         # Komer instance of ReportStats data class, keyed by SAID
         self.stats = None
+
+        if (mapSize := os.getenv(self.KERIBaserMapSizeKey)) is not None:
+            try:
+                self.MapSize = int(mapSize)
+            except ValueError:
+                print("KERI_BASER_MAP_SIZE must be an integer value >1!")
+                raise
 
         super(VerifierBaser, self).__init__(name=name, headDirPath=headDirPath, reopen=reopen, **kwa)
 

--- a/src/verifier/core/reporting.py
+++ b/src/verifier/core/reporting.py
@@ -101,12 +101,12 @@ class Filer:
             contentType=typ,
             size=0
         )
-
+        chunk_size = os.getenv("FILER_CHUNK_SIZE", 4194304)
         idx = 0
         diger = DigerBuilder.sha256(dig)
         report = b''
         while True:
-            chunk = stream.read(4194304)
+            chunk = stream.read(chunk_size)
             report += chunk
             if not chunk:
                 break

--- a/src/verifier/core/reporting.py
+++ b/src/verifier/core/reporting.py
@@ -179,6 +179,16 @@ class Filer:
             yield bytes(chunk)
             idx += 1
 
+
+    def clearData(self, dig):
+        idx = 0
+        while True:
+            key = f"{dig}.{idx}".encode("utf-8")
+            chunk = self.vdb.delIoVals(db=self.vdb.imgs, key=key)
+            if not chunk:
+                break
+            idx += 1
+
     def getAccepted(self):
         """ Generator that yields SAID values for all reports currently in Accepted status
 
@@ -479,7 +489,8 @@ class ReportVerifier(doing.Doer):
                 msg = e.args[0]
                 changes.append((said, ReportStatus.failed, msg))
                 logger.info(f"Added failed status message {msg}")
-                
+            finally:
+                self.filer.clearData(said)
         for said, status, msg in changes:
             self.filer.update(said, ReportStatus.accepted, status, msg)
             logger.info(f"Changed {said} {status} status message {msg}")


### PR DESCRIPTION
**Verifier Service Release Notes**

**Running the Verifier Service**

**Configuration:**  
To run the Verifier service, you need to specify a configuration file by providing the following arguments:  
`--config-dir=scripts --config-file='your_config_file'`

**Configuration Files Location:**  
Configuration files are located in the following directory:  
`scripts/keri/cf`

**Configurable Parameters:**  
You can customize the service behavior using these options:

-   **iurls**: OOBI URLs
-   **durls**: Schema OOBI URLs
-   **trustedLeis**: A list of trusted LE identifiers.
-   **allowedEcrRoles**: Roles permitted for ECR credential authorization.
-   **allowedOorRoles**: Roles permitted for OOR credential authorization.
-   **allowedSchemas**: A list of schemas allowed for authorization.

**Environment Variables:**  
You can export the following environment variables to modify runtime behavior:

-   **VERIFIER_ENV**: Set to `dev` or `production`. When set to `production`, the `/root_of_trust` endpoint is disabled. Default: `production`.
-   **VERIFY_ROOT_OF_TRUST**: Set to `True` or `False`. Enables or disables root of trust validation logic. Default: `True`.
-   **KERI_BASER_MAP_SIZE**: Defines the maximum size for the LMDB database. Default: `104857600` (100 MB).

**Example:**  
Run the Verifier service with the following command:  
`verifier server start--config-dir=scripts --config-file='verifier-config-public.json'`

----------

**LMDB Reports Data Cleanup**

The Verifier now includes automatic cleanup of reports after processing:

-   Processed reports are removed from the LMDB database to prevent size issues.
-   This update addresses crashes caused by the LMDB table exceeding the size defined by `KERI_BASER_MAP_SIZE`.

----------

**Bug Fixes**

-   Resolved an issue where uploading multiple reports caused the Verifier to crash with the error:  
    `lmdb.MapFullError: mdb_put: MDB_MAP_FULL: Environment mapsize limit reached`

----------

**Summary**  
This release introduces:

-   Configurable parameters for better customization.
-   Support for environment variables to adapt to different environments.
-   Automatic LMDB cleanup to enhance stability and prevent size-related crashes.
